### PR TITLE
Fix compilation errors for Flutter 3.27.1

### DIFF
--- a/lib/raw_image_provider.dart
+++ b/lib/raw_image_provider.dart
@@ -73,7 +73,7 @@ class _RawImageKey {
 
   @override
   int get hashCode {
-    return hashValues(w, h, format, dataHash.hashCode);
+    return Object.hash(w, h, format, dataHash.hashCode);
   }
 }
 


### PR DESCRIPTION
This is to fix the error when using with the latest Flutter version - 3.27.1